### PR TITLE
Allow custom dnsmasq_router when set as string.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,9 +16,7 @@ dnsmasq_dhcpv6: True
 # hosts, DHCPv6 doesn't work)
 # True means to announce the machine where dnsmasq is running as default gateway.
 # False means to not announce any default route.
-# If dnsmasq_router is a string, it will be announced as default gateway.
 dnsmasq_router: True
-# dnsmasq_router: '{{ ansible_default_ipv4.gateway }}'
 
 # Enable or disable TFTP server
 dnsmasq_tftp: True
@@ -72,6 +70,11 @@ dnsmasq_interfaces:
 
     # DHCPv6 options configured on this interface
     ipv6_mode: 'ra-names,ra-stateless,slaac'
+
+    # Address which dnsmasq will announce as default gateway via DHCPv4.
+    # The default, as defined by dnsmasq_router is to announce the machine
+    # running dnsmasq as default gateway.
+    # gateway: '{{ ansible_default_ipv4.gateway }}'
 
 
 # ---- DNS options ----

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,7 +27,7 @@ dnsmasq_bind_interfaces: True
 # Block private IP addresses coming from upstream nameservers
 dnsmasq_stop_dns_rebind: True
 
-# Don't forwards reverse DNS lookups for private IP addresses
+# Don't forward reverse DNS lookups for private IP addresses
 dnsmasq_bogus_priv: True
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,11 @@ dnsmasq_dhcpv6: True
 
 # Enable or disable local router support (no routing information is sent to
 # hosts, DHCPv6 doesn't work)
+# True means to announce the machine where dnsmasq is running as default gateway.
+# False means to not announce any default route.
+# If dnsmasq_router is a string, it will be announced as default gateway.
 dnsmasq_router: True
+# dnsmasq_router: '{{ ansible_default_ipv4.gateway }}'
 
 # Enable or disable TFTP server
 dnsmasq_tftp: True
@@ -25,7 +29,7 @@ dnsmasq_bind_interfaces: True
 # Block private IP addresses coming from upstream nameservers
 dnsmasq_stop_dns_rebind: True
 
-# Don't forwars reverse DNS lookups for private IP addresses
+# Don't forwards reverse DNS lookups for private IP addresses
 dnsmasq_bogus_priv: True
 
 

--- a/templates/etc/dnsmasq.d/interface.conf.j2
+++ b/templates/etc/dnsmasq.d/interface.conf.j2
@@ -48,9 +48,13 @@ dhcp-range = set:{{ item.interface }},{{ element | ipv6(item.dhcp_range_start | 
 
 {% endif %}
 {% endif %}
-{% if dnsmasq_router is defined and dnsmasq_router %}
+{% if dnsmasq_router is defined and dnsmasq_router is not string and dnsmasq_router %}
 # IPv4 router advertisement
 dhcp-option = tag:{{ item.interface }},option:router,0.0.0.0
+
+{% elif dnsmasq_router is string %}
+# IPv4 router
+dhcp-option = tag:{{ item.interface }},option:router,{{ dnsmasq_router }}
 
 {% else %}
 # IPv4 router advertisements are disabled

--- a/templates/etc/dnsmasq.d/interface.conf.j2
+++ b/templates/etc/dnsmasq.d/interface.conf.j2
@@ -48,13 +48,13 @@ dhcp-range = set:{{ item.interface }},{{ element | ipv6(item.dhcp_range_start | 
 
 {% endif %}
 {% endif %}
-{% if dnsmasq_router is defined and dnsmasq_router is not string and dnsmasq_router %}
+{% if dnsmasq_router is defined and dnsmasq_router and item.gateway is not string %}
 # IPv4 router advertisement
 dhcp-option = tag:{{ item.interface }},option:router,0.0.0.0
 
-{% elif dnsmasq_router is string %}
+{% elif dnsmasq_router is defined and dnsmasq_router and item.gateway is string %}
 # IPv4 router
-dhcp-option = tag:{{ item.interface }},option:router,{{ dnsmasq_router }}
+dhcp-option = tag:{{ item.interface }},option:router,{{ item.gateway }}
 
 {% else %}
 # IPv4 router advertisements are disabled


### PR DESCRIPTION
* The previous behavior was not flexible enough as it only allowed to
  announce the dnsmasq system as default gateway or to not announce any
  default route via DHCPv4.

* Maybe use another variable for this?