### PR TITLE
use ascii apostrophe in comments

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -170,7 +170,7 @@ dnsmasq_cname: {}
 
 # .. envvar:: dnsmasq_nameservers
 #
-# List of upstream DNS resolvers where dnsmasq should forward it’s DNS queries
+# List of upstream DNS resolvers where dnsmasq should forward it's DNS queries
 # which it can not answer by itself to. If set to ``False`` it will use the
 # systems nameservers.
 dnsmasq_nameservers: []


### PR DESCRIPTION
Eliminates UnicodeDecodeError when using debops-defaults.
