### PR TITLE
[+] add a template snippet to render dhcp-host directives.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -261,6 +261,16 @@ dnsmasq__dns_not_forward_managed: |
   local = /{{ dnsmasq__domain }}/
 
 
+# .. envvar:: dnsmasq__dhcp_hosts
+#
+# List of hosts that are assigned fixed IPs and names in DNS based on their MAC addr.
+dnsmasq__dhcp_hosts:
+  - name: client
+    mac: '01:23:45:67:89:ab'
+    ip: '192.168.0.42'
+    # optional; default: 1d
+    lease_time: 12h
+
 # .. envvar:: dnsmasq__options
 #
 # Additional options passed as a YAML text block.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -264,12 +264,7 @@ dnsmasq__dns_not_forward_managed: |
 # .. envvar:: dnsmasq__dhcp_hosts
 #
 # List of hosts that are assigned fixed IPs and names in DNS based on their MAC addr.
-dnsmasq__dhcp_hosts:
-  - name: client
-    mac: '01:23:45:67:89:ab'
-    ip: '192.168.0.42'
-    # optional; default: 1d
-    lease_time: 12h
+dnsmasq__dhcp_hosts: []
 
 # .. envvar:: dnsmasq__options
 #

--- a/docs/defaults-detailed.rst
+++ b/docs/defaults-detailed.rst
@@ -1,3 +1,18 @@
+Default variable details
+========================
+
+Some of ``debops.dnsmasq`` default variables have more extensive
+configuration than simple strings or lists, here you can find documentation and
+examples for them.
+
+.. contents::
+   :local:
+   :depth: 1
+
+.. dnsmasq__dhcp_hosts:
+
+dnsmasq__dhcp_hosts
+-------------------
 ``dnsmasq__dhcp_hosts`` must be a list of hosts. Each host is a dictionary
 consisting of a ``name``, a ``mac`` address, an ``ip`` address and optionally a
 ``lease_time``; by default it's 1 day (``1d``).::

--- a/docs/defaults-detailed.rst
+++ b/docs/defaults-detailed.rst
@@ -1,0 +1,10 @@
+``dnsmasq__dhcp_hosts`` must be a list of hosts. Each host is a dictionary
+consisting of a ``name``, a ``mac`` address, an ``ip`` address and optionally a
+``lease_time``; by default it's 1 day (``1d``).::
+
+    dnsmasq__dhcp_hosts:
+      - name: client
+        mac: '01:23:45:67:89:ab'
+        ip: '192.168.0.42'
+        # optional; default: 1d
+        lease_time: 12h

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,6 +7,7 @@ Ansible role: debops.dnsmasq
    :maxdepth: 2
 
    defaults
+   defaults-detailed
    copyright
    changelog
 

--- a/templates/etc/dnsmasq.d/00_main.conf.j2
+++ b/templates/etc/dnsmasq.d/00_main.conf.j2
@@ -164,6 +164,13 @@ resolv-file = /etc/resolvconf/upstream.conf
 {{ dnsmasq__dns_not_forward_private }}
 {% endif %}
 
+{% if dnsmasq__dhcp_hosts is defined %}
+{% for host in dnsmasq__dhcp_hosts %}
+dhcp-host={{ host.mac }},{{ host.ip  }}{% if host.name is defined %},{{ host.name }}{% else %}{% if host.lease_time is defined %},{% endif %}{% endif %}{% if host.lease_time is defined %},{{ host.lease_time }}{% else %},1d{% endif %}
+
+{% endfor %}
+{% endif %}
+
 {% if dnsmasq__options|d() %}
 # ---- Global custom options ----
 


### PR DESCRIPTION
This part of the template was taken from [here](https://github.com/bertvv/ansible-dnsmasq/blob/master/templates/etc_dnsmasq.conf.j2#L41). As discussed int the IRC channel, the license seems to be compatible. An example of how to define the hosts [here](https://github.com/bertvv/ansible-dnsmasq#dhcp-settings).