### PR TITLE
Persistent config on Qubes OS using `debops.persistent_paths`

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,8 +1,8 @@
 debops.dnsmasq - Install and configure dnsmasq
 
-Copyright (C) 2014-2016 Maciej Delmanowski <drybjed@gmail.com>
-Copyright (C) 2015-2016 Robin Schneider <ypid@riseup.net>
-Copyright (C) 2014-2016 DebOps https://debops.org/
+Copyright (C) 2014-2017 Maciej Delmanowski <drybjed@gmail.com>
+Copyright (C) 2015-2017 Robin Schneider <ypid@riseup.net>
+Copyright (C) 2014-2017 DebOps https://debops.org/
 
 This Ansible role is part of DebOps.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -303,19 +303,6 @@ dnsmasq__group_options: ''
 dnsmasq__host_options: ''
 
                                                                    # ]]]
-# .. envvar:: dnsmasq__persistent_prefix_path [[[
-#
-# Directory path prefix which should be used for writing/updating of files made
-# persistent by :envvar:`dnsmasq__persistent_paths__dependent_paths`.
-dnsmasq__persistent_prefix_path: '{{ ansible_local.persistent_paths.storage_path|d("")
-                                     if (ansible_local|d() and
-                                         ansible_local.dnsmasq|d() and
-                                         ansible_local.dnsmasq.enabled|d() | bool and
-                                         ansible_local.persistent_paths|d() and
-                                         ansible_local.persistent_paths.enabled|d() | bool and
-                                         ansible_local.persistent_paths.write_to_storage_path|d() | bool)
-                                     else "" }}'
-                                                                   # ]]]
                                                                    # ]]]
 # Configuration for other Ansible roles [[[
 # -----------------------------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,38 +10,37 @@
 # .. include:: includes/all.rst
 
 
-# ------------------------------------
-#   Global options
-# ------------------------------------
+# Global options [[[
+# ------------------
 
-# .. envvar:: dnsmasq__public_dns
+# .. envvar:: dnsmasq__public_dns [[[
 #
 # Enable or disable access to the local DNS from upstream networks. You can
 # publish your subdomain in the public DNS by delegating it in your zone
 # configuration.
 dnsmasq__public_dns: False
 
-
-# .. envvar:: dnsmasq__external_dns
+                                                                   # ]]]
+# .. envvar:: dnsmasq__external_dns [[[
 #
 # Enable or disable external DNS support.
 # If set to ``False`` then only allow DNS queries from localhost.
 dnsmasq__external_dns: True
 
-
-# .. envvar:: dnsmasq__dhcpv4
+                                                                   # ]]]
+# .. envvar:: dnsmasq__dhcpv4 [[[
 #
 # Enable or disable DHCPv4 support.
 dnsmasq__dhcpv4: True
 
-
-# .. envvar:: dnsmasq__dhcpv6
+                                                                   # ]]]
+# .. envvar:: dnsmasq__dhcpv6 [[[
 #
 # Enable or disable DHCPv6 support (router support is required).
 dnsmasq__dhcpv6: True
 
-
-# .. envvar:: dnsmasq__router
+                                                                   # ]]]
+# .. envvar:: dnsmasq__router [[[
 #
 # Enable or disable local router support (no routing information is sent to
 # hosts, DHCPv6 doesn't work).
@@ -50,26 +49,26 @@ dnsmasq__dhcpv6: True
 # ``False`` means to not announce any default route.
 dnsmasq__router: True
 
-
-# .. envvar:: dnsmasq__tftp
+                                                                   # ]]]
+# .. envvar:: dnsmasq__tftp [[[
 #
 # Enable or disable TFTP server.
 dnsmasq__tftp: True
 
-
-# .. envvar:: dnsmasq__bind_interfaces
+                                                                   # ]]]
+# .. envvar:: dnsmasq__bind_interfaces [[[
 #
 # Bind to and listen only on specified interfaces.
 dnsmasq__bind_interfaces: True
 
-
-# .. envvar:: dnsmasq__stop_dns_rebind
+                                                                   # ]]]
+# .. envvar:: dnsmasq__stop_dns_rebind [[[
 #
 # Block private IP addresses coming from upstream nameservers.
 dnsmasq__stop_dns_rebind: True
 
-
-# .. envvar:: dnsmasq__bogus_priv
+                                                                   # ]]]
+# .. envvar:: dnsmasq__bogus_priv [[[
 #
 # Don't forward reverse DNS queries for private IP addresses to upstream DNS servers.
 # The default is to not forward reverse DNS queries if the
@@ -79,39 +78,38 @@ dnsmasq__bogus_priv: '{{ dnsmasq__ipv4_gateway|d() and
                          hostvars[inventory_hostname]["ansible_" + dnsmasq__ipv4_gateway].ipv4|d() and
                          ([ hostvars[inventory_hostname]["ansible_" + dnsmasq__ipv4_gateway].ipv4.address ]
                            | ipaddr("public") | d([]) | length) >= 1 }}'
+                                                                   # ]]]
+                                                                   # ]]]
+# Network interface options [[[
+# -----------------------------
 
-
-# ------------------------------------
-#   Network interface options
-# ------------------------------------
-
-# .. envvar:: dnsmasq__upstream_interfaces
+# .. envvar:: dnsmasq__upstream_interfaces [[[
 #
 # List of network interfaces that are assumed to be upstream networks, if
 # present on the host.
 dnsmasq__upstream_interfaces: [ 'br0', 'br1', 'eth0', 'eth1' ]
 
-
-# .. envvar:: dnsmasq__no_dhcp_interfaces
+                                                                   # ]]]
+# .. envvar:: dnsmasq__no_dhcp_interfaces [[[
 #
 # List of network interfaces where dnsmasq should not provide DHCP or RA.
 # See https://github.com/debops/ansible-dnsmasq/issues/13 for more information.
 dnsmasq__no_dhcp_interfaces: []
 
-
-# .. envvar:: dnsmasq__ipv4_gateway
+                                                                   # ]]]
+# .. envvar:: dnsmasq__ipv4_gateway [[[
 #
 # Name of the IPv4 gateway interface.
 dnsmasq__ipv4_gateway: '{{ ansible_default_ipv4.interface | default("") }}'
 
-
-# .. envvar:: dnsmasq__ipv6_gateway
+                                                                   # ]]]
+# .. envvar:: dnsmasq__ipv6_gateway [[[
 #
 # Name of the IPv6 gateway interface.
 dnsmasq__ipv6_gateway: '{{ ansible_default_ipv6.interface | default("") }}'
 
-
-# .. envvar:: dnsmasq__interfaces
+                                                                   # ]]]
+# .. envvar:: dnsmasq__interfaces [[[
 #
 # List of internal interfaces on which dnsmasq will configure its services.
 dnsmasq__interfaces:
@@ -141,26 +139,25 @@ dnsmasq__interfaces:
     # The default, as defined by `dnsmasq__router` is to announce the machine
     # running dnsmasq as default gateway.
     # gateway: '{{ ansible_default_ipv4.gateway }}'
+                                                                   # ]]]
+                                                                   # ]]]
+# DNS options [[[
+# ---------------
 
-
-# ------------------------------------
-#   DNS options
-# ------------------------------------
-
-# .. envvar:: dnsmasq__domain
+# .. envvar:: dnsmasq__domain [[[
 #
 # DNS domain configured by dnsmasq for all local networks.
 dnsmasq__domain: '{{ ansible_domain }}'
 
-
-# .. envvar:: dnsmasq__domain_mx
+                                                                   # ]]]
+# .. envvar:: dnsmasq__domain_mx [[[
 #
 # Set DNS MX record of the main domain to dnsmasq host. Set to ``False`` to
 # disable.
 dnsmasq__domain_mx: '{{ ansible_fqdn }}'
 
-
-# .. envvar:: dnsmasq__etc_hosts
+                                                                   # ]]]
+# .. envvar:: dnsmasq__etc_hosts [[[
 #
 # List of file paths of :manpage:`hosts(5)` files to read by dnsmasq. The default,
 # no hosts file is being read.
@@ -172,15 +169,15 @@ dnsmasq__domain_mx: '{{ ansible_fqdn }}'
 # itself.
 dnsmasq__etc_hosts: []
 
-
-# .. envvar:: dnsmasq__search
+                                                                   # ]]]
+# .. envvar:: dnsmasq__search [[[
 #
 # List of additional search domains. Set ref:`dnsmasq__search` to False
 # to completely disable this functionality.
 dnsmasq__search: '{{ [ dnsmasq__domain, ansible_domain ] | unique }}'
 
-
-# .. envvar:: dnsmasq__cname
+                                                                   # ]]]
+# .. envvar:: dnsmasq__cname [[[
 #
 # Hash of DNS CNAME records to configure for hosts found in local DNS.
 # Entries should be specified without the domain suffix.
@@ -192,42 +189,40 @@ dnsmasq__search: '{{ [ dnsmasq__domain, ansible_domain ] | unique }}'
 #
 dnsmasq__cname: {}
 
-
-# .. envvar:: dnsmasq__nameservers
+                                                                   # ]]]
+# .. envvar:: dnsmasq__nameservers [[[
 #
 # List of upstream DNS resolvers where dnsmasq should forward it's DNS queries
 # which it can not answer by itself to. If set to ``False`` it will use the
 # systems nameservers.
 dnsmasq__nameservers: []
+                                                                   # ]]]
+                                                                   # ]]]
+# TFTP options [[[
+# ----------------
 
-
-# ------------------------------------
-#   TFTP options
-# ------------------------------------
-
-# .. envvar:: dnsmasq__tftp_root
+# .. envvar:: dnsmasq__tftp_root [[[
 #
 # Path to TFTP root directory.
 dnsmasq__tftp_root: '/srv/tftp'
 
-
-# .. envvar:: dnsmasq__tftp_boot
+                                                                   # ]]]
+# .. envvar:: dnsmasq__tftp_boot [[[
 #
 # BOOTP command passed to clients (see dhcp-boot in dnsmasq(8)).
 dnsmasq__tftp_boot: 'menu.ipxe'
 
-
-# .. envvar:: dnsmasq__tftp_ipxe
+                                                                   # ]]]
+# .. envvar:: dnsmasq__tftp_ipxe [[[
 #
 # Enable iPXE support.
 dnsmasq__tftp_ipxe: True
+                                                                   # ]]]
+                                                                   # ]]]
+# Other options [[[
+# -----------------
 
-
-# ------------------------------------
-#   Other options
-# ------------------------------------
-
-# .. envvar:: dnsmasq__dns_not_forward_reserved
+# .. envvar:: dnsmasq__dns_not_forward_reserved [[[
 #
 # Don’t forward the following reserved top level DNS names to upstream DNS
 # servers.
@@ -241,8 +236,8 @@ dnsmasq__dns_not_forward_reserved: |
   ## Ref: https://tools.ietf.org/html/rfc7686
   local = /onion/
 
-
-# .. envvar:: dnsmasq__dns_not_forward_private
+# ]]]
+# .. envvar:: dnsmasq__dns_not_forward_private [[[
 #
 # Don’t forward the following private top level DNS names to upstream DNS
 # servers because RFC 6762 recommends not to use unregistered top-level
@@ -251,8 +246,8 @@ dnsmasq__dns_not_forward_reserved: |
 dnsmasq__dns_not_forward_private: |
   local = /intranet/internal/private/corp/home/lan/
 
-
-# .. envvar:: dnsmasq__dns_not_forward_managed
+# ]]]
+# .. envvar:: dnsmasq__dns_not_forward_managed [[[
 #
 # Don’t forward queries for :envvar:`dnsmasq__domain` to upstream DNS
 # servers.
@@ -260,34 +255,35 @@ dnsmasq__dns_not_forward_managed: |
   # Domain managed by the dnsmasq DNS server.
   local = /{{ dnsmasq__domain }}/
 
-
-# .. envvar:: dnsmasq__dhcp_hosts
+# ]]]
+# .. envvar:: dnsmasq__dhcp_hosts [[[
 #
 # List of hosts that are assigned fixed IPs and names in DNS based on their MAC addr.
 dnsmasq__dhcp_hosts: []
 
-# .. envvar:: dnsmasq__options
+                                                                   # ]]]
+# .. envvar:: dnsmasq__options [[[
 #
 # Additional options passed as a YAML text block.
 # This variable is intended to be used in Ansible’s global inventory.
 dnsmasq__options: ''
 
-
-# .. envvar:: dnsmasq__group_options
+                                                                   # ]]]
+# .. envvar:: dnsmasq__group_options [[[
 #
 # Additional options passed as a YAML text block.
 # This variable is intended to be used in a host inventory group of Ansible
 # (only one host group is supported).
 dnsmasq__group_options: ''
 
-
-# .. envvar:: dnsmasq__host_options
+                                                                   # ]]]
+# .. envvar:: dnsmasq__host_options [[[
 #
 # Additional options passed as a YAML text block.
 # This variable is intended to be used in the inventory of hosts.
 dnsmasq__host_options: ''
-
-
+                                                                   # ]]]
+                                                                   # ]]]
 # Configuration for other Ansible roles [[[
 # -----------------------------------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,21 @@
 # .. include:: includes/all.rst
 
 
+# APT packages [[[
+# ----------------
+
+# .. envvar:: dnsmasq__base_packages [[[
+#
+# List of APT packages to install for ``dnsmasq`` support.
+dnsmasq__base_packages: [ 'dnsmasq', 'resolvconf' ]
+
+                                                                   # ]]]
+# .. envvar:: dnsmasq__packages [[[
+#
+# List of additional APT packages to install during ``dnsmasq`` configuration.
+dnsmasq__packages: []
+                                                                   # ]]]
+                                                                   # ]]]
 # Global options [[[
 # ------------------
 
@@ -147,7 +162,10 @@ dnsmasq__interfaces:
 # .. envvar:: dnsmasq__domain [[[
 #
 # DNS domain configured by dnsmasq for all local networks.
-dnsmasq__domain: '{{ ansible_domain }}'
+dnsmasq__domain: '{{ ansible_local.core.domain
+                     if (ansible_local|d() and ansible_local.core|d() and
+                         ansible_local.core.domain|d())
+                     else (ansible_domain if ansible_domain else ansible_hostname) }}'
 
                                                                    # ]]]
 # .. envvar:: dnsmasq__domain_mx [[[
@@ -282,6 +300,20 @@ dnsmasq__group_options: ''
 # Additional options passed as a YAML text block.
 # This variable is intended to be used in the inventory of hosts.
 dnsmasq__host_options: ''
+
+                                                                   # ]]]
+# .. envvar:: dnsmasq__persistent_prefix_path [[[
+#
+# Directory path prefix which should be used for writing/updating of files made
+# persistent by :envvar:`dnsmasq__persistent_paths__dependent_paths`.
+dnsmasq__persistent_prefix_path: '{{ ansible_local.persistent_paths.storage_path|d("")
+                                     if (ansible_local|d() and
+                                         ansible_local.dnsmasq|d() and
+                                         ansible_local.dnsmasq.enabled|d() | bool and
+                                         ansible_local.persistent_paths|d() and
+                                         ansible_local.persistent_paths.enabled|d() | bool and
+                                         ansible_local.persistent_paths.write_to_storage_path|d() | bool)
+                                     else "" }}'
                                                                    # ]]]
                                                                    # ]]]
 # Configuration for other Ansible roles [[[
@@ -351,6 +383,21 @@ dnsmasq__apparmor__local_dependent_config:
     - comment: 'Allow dnsmasq to read /usr/share/dnsmasq-base/trust-anchors.conf provided by dnsmasq-base'
       rules:
         - '/usr/share/dnsmasq-base/* r'
+
+                                                                   # ]]]
+# .. envvar:: dnsmasq__persistent_paths__dependent_paths [[[
+#
+# Configuration for the debops.persistent_paths_ Ansible role.
+dnsmasq__persistent_paths__dependent_paths:
+
+  '50_debops_dnsmasq':
+    by_role: 'debops.dnsmasq'
+    paths:
+      - '/etc/ansible'
+      - '/etc/dnsmasq.d'
+      - '/etc/default/dnsmasq'
+      - '/etc/resolvconf/upstream.conf'
+      - '/etc/hosts.dnsmasq'
                                                                    # ]]]
                                                                    # ]]]
                                                                    # ]]]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -214,32 +214,8 @@ dnsmasq__cname: {}
 # which it can not answer by itself to. If set to ``False`` it will use the
 # systems nameservers.
 dnsmasq__nameservers: []
-                                                                   # ]]]
-                                                                   # ]]]
-# TFTP options [[[
-# ----------------
-
-# .. envvar:: dnsmasq__tftp_root [[[
-#
-# Path to TFTP root directory.
-dnsmasq__tftp_root: '/srv/tftp'
 
                                                                    # ]]]
-# .. envvar:: dnsmasq__tftp_boot [[[
-#
-# BOOTP command passed to clients (see dhcp-boot in dnsmasq(8)).
-dnsmasq__tftp_boot: 'menu.ipxe'
-
-                                                                   # ]]]
-# .. envvar:: dnsmasq__tftp_ipxe [[[
-#
-# Enable iPXE support.
-dnsmasq__tftp_ipxe: True
-                                                                   # ]]]
-                                                                   # ]]]
-# Other options [[[
-# -----------------
-
 # .. envvar:: dnsmasq__dns_not_forward_reserved [[[
 #
 # Don’t forward the following reserved top level DNS names to upstream DNS
@@ -274,6 +250,31 @@ dnsmasq__dns_not_forward_managed: |
   local = /{{ dnsmasq__domain }}/
 
 # ]]]
+# ]]]
+# TFTP options [[[
+# ----------------
+
+# .. envvar:: dnsmasq__tftp_root [[[
+#
+# Path to TFTP root directory.
+dnsmasq__tftp_root: '/srv/tftp'
+
+                                                                   # ]]]
+# .. envvar:: dnsmasq__tftp_boot [[[
+#
+# BOOTP command passed to clients (see dhcp-boot in dnsmasq(8)).
+dnsmasq__tftp_boot: 'menu.ipxe'
+
+                                                                   # ]]]
+# .. envvar:: dnsmasq__tftp_ipxe [[[
+#
+# Enable iPXE support.
+dnsmasq__tftp_ipxe: True
+                                                                   # ]]]
+                                                                   # ]]]
+# Other options [[[
+# -----------------
+
 # .. envvar:: dnsmasq__dhcp_hosts [[[
 #
 # List of hosts that are assigned fixed IPs and names in DNS based on their MAC addr.

--- a/docs/defaults-detailed.rst
+++ b/docs/defaults-detailed.rst
@@ -13,13 +13,15 @@ examples for them.
 
 dnsmasq__dhcp_hosts
 -------------------
-``dnsmasq__dhcp_hosts`` must be a list of hosts. Each host is a dictionary
-consisting of a ``name``, a ``mac`` address, an ``ip`` address and optionally a
-``lease_time``; by default it's 1 day (``1d``).::
+:envvar:`dnsmasq__dhcp_hosts` must be a list of hosts. Each host is a dictionary
+consisting of a ``name``, a ``mac`` address, an :command:`ip` address and optionally a
+``lease_time``; by default it's 1 day (``1d``).:
 
-    dnsmasq__dhcp_hosts:
-      - name: client
-        mac: '01:23:45:67:89:ab'
-        ip: '192.168.0.42'
-        # optional; default: 1d
-        lease_time: 12h
+.. code-block:: yaml
+
+   dnsmasq__dhcp_hosts:
+     - name: client
+       mac: '01:23:45:67:89:ab'
+       ip: '192.168.0.42'
+       # optional; default: 1d
+       lease_time: 12h

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -52,4 +52,11 @@ so that the changes can be made persistent:
    [debops_service_dnsmasq_persistent_paths]
    hostname
 
-The :envvar:`dnsmasq__base_packages` are expected to be present (typically installed in the TemplateVM).
+The :envvar:`dnsmasq__base_packages` are expected to be present (typically
+installed in the TemplateVM).
+
+Note that you will need to set ``core__unsafe_writes`` to ``True`` when you
+attempt to update the configuration on a system that uses bind mounts for
+persistence. You can set ``core__unsafe_writes`` directly in your inventory
+without the need to run the ``debops.core`` role for this special case.
+Refer to `Templating or updating persistent files`_ for details.

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -42,14 +42,14 @@ debops.persistent_paths_ support
 --------------------------------
 
 In case the host in question happens to be a TemplateBasedVM on `Qubes OS`_ or
-another system where persistence is not the default, it should absent in
-``debops_service_dnsmasq`` and instead be added to
-``debops_service_tinc_persistent_paths`` so that the changes can be made
-persistently:
+another system where persistence is not the default, it should be absent in
+``debops_service_dnsmasq`` and instead be added to the
+``debops_service_dnsmasq_persistent_paths`` Ansible inventory group
+so that the changes can be made persistent:
 
 .. code:: ini
 
-   [debops_service_tinc_persistent_paths]
+   [debops_service_dnsmasq_persistent_paths]
    hostname
 
 The :envvar:`dnsmasq__base_packages` are expected to be present (typically installed in the TemplateVM).

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -1,0 +1,55 @@
+Getting started
+===============
+
+.. contents::
+   :local:
+
+.. include:: includes/all.rst
+
+Example inventory
+-----------------
+
+Hosts added to the ``debops_service_dnsmasq`` inventory group will have the
+``dnsmasq`` installed and configured.
+
+.. code:: ini
+
+   [debops_service_dnsmasq]
+   hostname
+
+Example playbook
+----------------
+
+If you are using this role without DebOps, here's an example Ansible playbook
+that uses the ``debops.dnsmasq`` role:
+
+.. literalinclude:: playbooks/dnsmasq-plain.yml
+   :language: yaml
+
+If you are using this role without DebOps, here's an example Ansible playbook
+that uses ``debops.dnsmasq`` together with the debops.persistent_paths_ role:
+
+.. literalinclude:: playbooks/dnsmasq-persistent_paths.yml
+   :language: yaml
+
+If you are using this role without DebOps, here's an example Ansible playbook
+that uses ``debops.dnsmasq`` together with the debops-contrib.apparmor_ role:
+
+.. literalinclude:: playbooks/dnsmasq-apparmor.yml
+   :language: yaml
+
+debops.persistent_paths_ support
+--------------------------------
+
+In case the host in question happens to be a TemplateBasedVM on `Qubes OS`_ or
+another system where persistence is not the default, it should absent in
+``debops_service_dnsmasq`` and instead be added to
+``debops_service_tinc_persistent_paths`` so that the changes can be made
+persistently:
+
+.. code:: ini
+
+   [debops_service_tinc_persistent_paths]
+   hostname
+
+The :envvar:`dnsmasq__base_packages` are expected to be present (typically installed in the TemplateVM).

--- a/docs/includes/all.rst
+++ b/docs/includes/all.rst
@@ -1,1 +1,2 @@
 .. include:: includes/global.rst
+.. include:: includes/role.rst

--- a/docs/includes/role.rst
+++ b/docs/includes/role.rst
@@ -1,0 +1,1 @@
+.. _Templating or updating persistent files: https://docs.debops.org/en/latest/ansible/roles/ansible-persistent_paths/docs/guides.html#templating-or-updating-persistent-files

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@ Ansible role: debops.dnsmasq
 .. toctree::
    :maxdepth: 2
 
+   getting-started
    defaults
    defaults-detailed
    copyright

--- a/docs/playbooks/dnsmasq-persistent_paths.yml
+++ b/docs/playbooks/dnsmasq-persistent_paths.yml
@@ -1,0 +1,23 @@
+---
+
+- name: Configure dnsmasq and ensure persistence
+  hosts: [ 'debops_service_dnsmasq' ]
+  become: True
+
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
+
+  roles:
+
+    - role: debops.ferm
+      tags: [ 'role::ferm' ]
+      ferm__dependent_rules:
+        - '{{ dnsmasq__ferm__dependent_rules }}'
+
+    - role: debops.dnsmasq
+      tags: [ 'role::dnsmasq' ]
+
+    - role: debops.persistent_paths
+      tags: [ 'role::persistent_paths' ]
+      persistent_paths__dependent_paths: '{{ dnsmasq__persistent_paths__dependent_paths }}'

--- a/docs/playbooks/dnsmasq-persistent_paths.yml
+++ b/docs/playbooks/dnsmasq-persistent_paths.yml
@@ -15,6 +15,9 @@
       ferm__dependent_rules:
         - '{{ dnsmasq__ferm__dependent_rules }}'
 
+    - role: debops.tcpwrappers
+      tags: [ 'role::tcpwrappers' ]
+
     - role: debops.dnsmasq
       tags: [ 'role::dnsmasq' ]
 

--- a/docs/playbooks/dnsmasq-persistent_paths.yml
+++ b/docs/playbooks/dnsmasq-persistent_paths.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Configure dnsmasq and ensure persistence
-  hosts: [ 'debops_service_dnsmasq' ]
+  hosts: [ 'debops_service_dnsmasq_persistent_paths' ]
   become: True
 
   environment: '{{ inventory__environment | d({})

--- a/docs/playbooks/dnsmasq-plain.yml
+++ b/docs/playbooks/dnsmasq-plain.yml
@@ -1,0 +1,24 @@
+---
+
+- name: Configure dnsmasq
+  hosts: [ 'debops_service_dnsmasq' ]
+  become: True
+
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
+
+  roles:
+
+    - role: debops.ferm
+      tags: [ 'role::ferm' ]
+      ferm__dependent_rules:
+        - '{{ dnsmasq__ferm__dependent_rules }}'
+
+    ## Included in the `common.yml` playbook and currently configured via
+    ## legacy config files in the debops.dnsmasq role.
+    # - role: debops.tcpwrappers
+    #   tags: [ 'role::tcpwrappers' ]
+
+    - role: debops.dnsmasq
+      tags: [ 'role::dnsmasq' ]

--- a/docs/playbooks/dnsmasq-plain.yml
+++ b/docs/playbooks/dnsmasq-plain.yml
@@ -15,10 +15,8 @@
       ferm__dependent_rules:
         - '{{ dnsmasq__ferm__dependent_rules }}'
 
-    ## Included in the `common.yml` playbook and currently configured via
-    ## legacy config files in the debops.dnsmasq role.
-    # - role: debops.tcpwrappers
-    #   tags: [ 'role::tcpwrappers' ]
+    - role: debops.tcpwrappers
+      tags: [ 'role::tcpwrappers' ]
 
     - role: debops.dnsmasq
       tags: [ 'role::dnsmasq' ]

--- a/docs/playbooks/dnsmasq.yml
+++ b/docs/playbooks/dnsmasq.yml
@@ -1,24 +1,5 @@
 ---
 
-- name: Configure dnsmasq
-  hosts: [ 'debops_service_dnsmasq' ]
-  become: True
+- include: dnsmasq-plain.yml
 
-  environment: '{{ inventory__environment | d({})
-                   | combine(inventory__group_environment | d({}))
-                   | combine(inventory__host_environment  | d({})) }}'
-
-  roles:
-
-    - role: debops.ferm
-      tags: [ 'role::ferm' ]
-      ferm__dependent_rules:
-        - '{{ dnsmasq__ferm__dependent_rules }}'
-
-    ## Included in the `common.yml` playbook and currently configured via
-    ## legacy config files in the debops.dnsmasq role.
-    # - role: debops.tcpwrappers
-    #   tags: [ 'role::tcpwrappers' ]
-
-    - role: debops.dnsmasq
-      tags: [ 'role::dnsmasq' ]
+- include: dnsmasq-persistent_paths.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,24 +25,30 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
+    unsafe_writes: '{{ True if (core__unsafe_writes|d(True if (ansible_local|d() and ansible_local.core|d()
+                       and ansible_local.core.unsafe_writes|d() | bool) else False) | bool) else omit }}'
   notify: [ 'Test and restart dnsmasq' ]
 
 - name: Configure defaults for dnsmasq service
   template:
     src: 'etc/default/dnsmasq.j2'
-    dest: '{{ dnsmasq__persistent_prefix_path + "/etc/default/dnsmasq" }}'
+    dest: '/etc/default/dnsmasq'
     owner: 'root'
     group: 'root'
     mode: '0644'
+    unsafe_writes: '{{ True if (core__unsafe_writes|d(True if (ansible_local|d() and ansible_local.core|d()
+                       and ansible_local.core.unsafe_writes|d() | bool) else False) | bool) else omit }}'
   notify: [ 'Test and restart dnsmasq' ]
 
 - name: Configure custom nameservers
   template:
     src: 'etc/resolvconf/upstream.conf.j2'
-    dest: '{{ dnsmasq__persistent_prefix_path + "/etc/resolvconf/upstream.conf" }}'
+    dest: '/etc/resolvconf/upstream.conf'
     owner: 'root'
     group: 'root'
     mode: '0644'
+    unsafe_writes: '{{ True if (core__unsafe_writes|d(True if (ansible_local|d() and ansible_local.core|d()
+                       and ansible_local.core.unsafe_writes|d() | bool) else False) | bool) else omit }}'
   notify: [ 'Test and restart dnsmasq' ]
   when: dnsmasq__nameservers|d()
 
@@ -53,6 +59,8 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
+    unsafe_writes: '{{ True if (core__unsafe_writes|d(True if (ansible_local|d() and ansible_local.core|d()
+                       and ansible_local.core.unsafe_writes|d() | bool) else False) | bool) else omit }}'
   with_items: '{{ dnsmasq__interfaces }}'
   when: item.interface is defined and item.interface
   notify: [ 'Test and restart dnsmasq' ]
@@ -78,6 +86,8 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
+    unsafe_writes: '{{ True if (core__unsafe_writes|d(True if (ansible_local|d() and ansible_local.core|d()
+                       and ansible_local.core.unsafe_writes|d() | bool) else False) | bool) else omit }}'
   with_items: '{{ dnsmasq__interfaces }}'
   when: (dnsmasq__tftp|bool and item.interface|d())
   notify: [ 'Assemble hosts.allow.d' ]
@@ -107,6 +117,8 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
+    unsafe_writes: '{{ True if (core__unsafe_writes|d(True if (ansible_local|d() and ansible_local.core|d()
+                       and ansible_local.core.unsafe_writes|d() | bool) else False) | bool) else omit }}'
   register: dnsmasq__register_facts
 
 - name: Reload facts if they were modified

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,8 @@
     name: '{{ item }}'
     state: 'present'
   with_flattened:
-    - [ 'dnsmasq', 'resolvconf' ]
+    - '{{ dnsmasq__base_packages }}'
+    - '{{ dnsmasq__packages }}'
 
 - name: Get list of local search domains
   shell: grep search /etc/resolv.conf | cut -d' ' -f2- | tr ' ' '\n'
@@ -29,7 +30,7 @@
 - name: Configure defaults for dnsmasq service
   template:
     src: 'etc/default/dnsmasq.j2'
-    dest: '/etc/default/dnsmasq'
+    dest: '{{ dnsmasq__persistent_prefix_path + "/etc/default/dnsmasq" }}'
     owner: 'root'
     group: 'root'
     mode: '0644'
@@ -38,12 +39,20 @@
 - name: Configure custom nameservers
   template:
     src: 'etc/resolvconf/upstream.conf.j2'
-    dest: '/etc/resolvconf/upstream.conf'
+    dest: '{{ dnsmasq__persistent_prefix_path + "/etc/resolvconf/upstream.conf" }}'
     owner: 'root'
     group: 'root'
     mode: '0644'
   notify: [ 'Test and restart dnsmasq' ]
   when: dnsmasq__nameservers|d()
+
+## Don’t remove the file and instead template an empty file if `dnsmasq__nameservers` is empty.
+## Ref: https://github.com/QubesOS/qubes-doc/pull/299#discussion_r106387538
+# - name: Remove custom nameservers
+#   file:
+#     path: '/etc/resolvconf/upstream.conf'
+#     state: 'absent'
+#   when: not dnsmasq__nameservers|d()
 
 - name: Create interface dnsmasq configuration
   template:
@@ -90,8 +99,25 @@
     mode: '0755'
   when: dnsmasq__tftp|bool
 
-- name: Remove custom nameservers
+# Ansible facts [[[
+- name: Make sure Ansible fact directory exists
   file:
-    path: '/etc/resolvconf/upstream.conf'
-    state: 'absent'
-  when: not dnsmasq__nameservers|d()
+    path: '/etc/ansible/facts.d'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+
+- name: Create local facts of dnsmasq
+  template:
+    src: 'etc/ansible/facts.d/dnsmasq.fact.j2'
+    dest: '/etc/ansible/facts.d/dnsmasq.fact'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  register: dnsmasq__register_facts
+
+- name: Reload facts if they were modified
+  action: setup
+  when: dnsmasq__register_facts|changed
+# ]]]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,14 +46,6 @@
   notify: [ 'Test and restart dnsmasq' ]
   when: dnsmasq__nameservers|d()
 
-## Don’t remove the file and instead template an empty file if `dnsmasq__nameservers` is empty.
-## Ref: https://github.com/QubesOS/qubes-doc/pull/299#discussion_r106387538
-# - name: Remove custom nameservers
-#   file:
-#     path: '/etc/resolvconf/upstream.conf'
-#     state: 'absent'
-#   when: not dnsmasq__nameservers|d()
-
 - name: Create interface dnsmasq configuration
   template:
     src: 'etc/dnsmasq.d/interface.conf.j2'

--- a/templates/etc/ansible/facts.d/dnsmasq.fact.j2
+++ b/templates/etc/ansible/facts.d/dnsmasq.fact.j2
@@ -1,0 +1,3 @@
+{{ ({
+    "enabled": True,
+}) | to_nice_json }}

--- a/templates/etc/resolvconf/upstream.conf.j2
+++ b/templates/etc/resolvconf/upstream.conf.j2
@@ -1,9 +1,9 @@
 # {{ ansible_managed }}
 
 {% if dnsmasq__nameservers|d() and dnsmasq__nameservers is iterable %}
-{% for nameserver in dnsmasq__nameservers %}
+{%   for nameserver in dnsmasq__nameservers %}
 nameserver {{ nameserver }}
-{% endfor %}
+{%   endfor %}
 {% elif dnsmasq__nameservers|d() and dnsmasq__nameservers is string %}
 nameserver {{ dnsmasq__nameservers }}
 {% endif %}


### PR DESCRIPTION
Depends on: debops/ansible-persistent_paths#4